### PR TITLE
Combine player prefabs and add Crow spawn/reset to 'boundary' scene

### DIFF
--- a/Assets/Prefabs/Player (ALERT).prefab
+++ b/Assets/Prefabs/Player (ALERT).prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 3593900074549987354}
   - component: {fileID: 2090794006302226085}
   - component: {fileID: 5565693240296418156}
+  - component: {fileID: 7092685075430961850}
   m_Layer: 0
   m_Name: SK_Mock
   m_TagString: Player
@@ -129,6 +130,33 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.022083445, y: 0.02208345, z: 0.12629895}
   m_Center: {x: -0.00000006676967, y: 0.0000000039550314, z: -0.008177273}
+--- !u!54 &7092685075430961850
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3776803786978641904}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &6404457502676479793
 GameObject:
   m_ObjectHideFlags: 0
@@ -142,7 +170,7 @@ GameObject:
   - component: {fileID: -4588261729875893500}
   m_Layer: 0
   m_Name: Player (ALERT)
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Player (ALERT).prefab
+++ b/Assets/Prefabs/Player (ALERT).prefab
@@ -284,6 +284,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Alert
       objectReference: {fileID: 0}
+    - target: {fileID: 3977317935005815858, guid: 7ea1054071d74eb4c887892da42db064,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/Player (ALERT).prefab
+++ b/Assets/Prefabs/Player (ALERT).prefab
@@ -139,6 +139,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8667427160858216469}
   - component: {fileID: 9086005286262994239}
+  - component: {fileID: -4588261729875893500}
   m_Layer: 0
   m_Name: Player (ALERT)
   m_TagString: Untagged
@@ -180,6 +181,18 @@ MonoBehaviour:
   gridPosition:
     x: 0
     z: 0
+--- !u!114 &-4588261729875893500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6404457502676479793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d705e2bdfed48c3824cc0adc18f806, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7958157850058083957
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BoundaryTestScene.unity
+++ b/Assets/Scenes/BoundaryTestScene.unity
@@ -203,7 +203,7 @@ MonoBehaviour:
   gameoverTriggerArea: {fileID: 467804832}
   GameoverPanel: {fileID: 1234380269}
   targetFPS: 60
-  playerPrefab: {fileID: 6404457502676479793, guid: b2ed011ac1ea54524a03634600711f56,
+  playerPrefab: {fileID: 6404457502676479793, guid: bc2412041f862244791ad02d37978d69,
     type: 3}
   playerStartCoords:
     x: 5

--- a/Assets/Scenes/BoundaryTestScene.unity
+++ b/Assets/Scenes/BoundaryTestScene.unity
@@ -217,6 +217,7 @@ MonoBehaviour:
   accelerationCurve: 0.1
   decelerationCurve: 0.3
   playerInCatchupZone: 0
+  crowManagerParent: {fileID: 1067131672}
 --- !u!4 &101821161
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BoundaryTestScene.unity
+++ b/Assets/Scenes/BoundaryTestScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18178011, g: 0.22745012, b: 0.3074199, a: 1}
+  m_IndirectSpecularColor: {r: 0.18178049, g: 0.22745068, b: 0.3074211, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1501,6 +1501,56 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1051125748}
   m_CullTransparentMesh: 1
+--- !u!1 &1067131672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1067131674}
+  - component: {fileID: 1067131673}
+  m_Layer: 0
+  m_Name: CrowManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1067131673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067131672}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d62d4345ab864c748a19358fa7a69f2f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  crowModel: {fileID: 4727883945757891228, guid: 084589d1b073c7e41a49e1b6f810a258,
+    type: 3}
+  playerAlert: {fileID: 0}
+  travelTime: 5
+  minSpawnDelay: 2
+  maxSpawnDelay: 5
+--- !u!4 &1067131674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1067131672}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 23.855524, y: 21.466072, z: 2.4849052}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1234380269
 GameObject:
   m_ObjectHideFlags: 0
@@ -2308,3 +2358,4 @@ SceneRoots:
   - {fileID: 1442115071}
   - {fileID: 286670813}
   - {fileID: 101821161}
+  - {fileID: 1067131674}

--- a/Assets/Scenes/BoundaryTestScene.unity
+++ b/Assets/Scenes/BoundaryTestScene.unity
@@ -217,7 +217,7 @@ MonoBehaviour:
   accelerationCurve: 0.1
   decelerationCurve: 0.3
   playerInCatchupZone: 0
-  crowManagerParent: {fileID: 1067131672}
+  crowManager: {fileID: 1067131673}
 --- !u!4 &101821161
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -37,7 +37,7 @@ public class CrowManager : MonoBehaviour
     /// <summary>
     /// Spawn an initial crow at a location
     /// </summary>
-    private void Start()
+    public void Start()
     {
         //Initial reference to alert gameobject
         if (playerAlert == null)

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -37,15 +37,6 @@ public class CrowManager : MonoBehaviour
     private int zPos = 0; //Initial z-axis location before updating with random value
 
     /// <summary>
-    /// Spawn an initial crow at a location
-    /// </summary>
-    public void Start()
-    {
-        GetAlertFromPlayer();
-        SpawnCrow();
-    }
-
-    /// <summary>
     /// Instantiates a Crow gameobject at a position offscreen (x-axis) at a random point on the z-axis
     /// Start Coroutine to move the crow
     /// </summary>
@@ -100,6 +91,19 @@ public class CrowManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Gets object tagged 'Alert' attached to the player, disable active until shown in MoveCrow()
+    /// </summary>
+    public void GetAlertFromPlayer()
+    {
+        //Initial reference to alert gameobject
+        if (playerAlert == null)
+        {
+            playerAlert = GameObject.FindWithTag("Alert");
+            playerAlert.SetActive(false);
+        }
+    }
+
+    /// <summary>
     /// Toggles the alert above the player to be active for half the crow travel time
     /// </summary>
     /// <returns>WaitForSeconds before hiding gameobject again</returns>
@@ -124,18 +128,5 @@ public class CrowManager : MonoBehaviour
     {
         StopAllCoroutines();
         spawnedCrow.transform.position = new Vector3(30f, 0f, 30f);
-    }
-
-    /// <summary>
-    /// Gets object tagged 'Alert' attached to the player, disable active until shown in MoveCrow()
-    /// </summary>
-    public void GetAlertFromPlayer()
-    {
-        //Initial reference to alert gameobject
-        if (playerAlert == null)
-        {
-            playerAlert = GameObject.FindWithTag("Alert");
-            playerAlert.SetActive(false);
-        }
     }
 }

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -14,7 +14,9 @@
  */
 
 using System.Collections;
+using Unity.VisualScripting;
 using UnityEngine;
+using static UnityEngine.Rendering.DebugUI.Table;
 
 public class CrowManager : MonoBehaviour
 {
@@ -39,12 +41,7 @@ public class CrowManager : MonoBehaviour
     /// </summary>
     public void Start()
     {
-        //Initial reference to alert gameobject
-        if (playerAlert == null)
-        {
-            playerAlert = GameObject.FindWithTag("Alert");
-        }
-
+        GetAlertFromPlayer();
         SpawnCrow();
     }
 
@@ -54,7 +51,7 @@ public class CrowManager : MonoBehaviour
     /// </summary>
     public void SpawnCrow()
     {
-        if (GameManager.instance.gameStarted == false) { return; }
+        //if (GameManager.instance.gameStarted == false) { return; } //Removed as causing issues with 'Play again' reset
 
         zPos = GetRandomZPos();
         crowPosition = new Vector3(startXPos, 0f, zPos);
@@ -119,4 +116,26 @@ public class CrowManager : MonoBehaviour
     /// </summary>
     /// <returns>z position for new crow spawn location</returns>
     private int GetRandomZPos() => Random.Range(2, 9);
+
+    /// <summary>
+    /// Stops movement of crow and moves offscreen for new game spawning 
+    /// </summary>
+    public void GameOver()
+    {
+        StopAllCoroutines();
+        spawnedCrow.transform.position = new Vector3(30f, 0f, 30f);
+    }
+
+    /// <summary>
+    /// Gets object tagged 'Alert' attached to the player, disable active until shown in MoveCrow()
+    /// </summary>
+    public void GetAlertFromPlayer()
+    {
+        //Initial reference to alert gameobject
+        if (playerAlert == null)
+        {
+            playerAlert = GameObject.FindWithTag("Alert");
+            playerAlert.SetActive(false);
+        }
+    }
 }

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -33,7 +33,7 @@ public class CrowManager : MonoBehaviour
     private const int startXPos = 16; //Offscreen X location 'ahead' of the player
     private const int endXPos = -10; //Offscreen X location 'behind' the player
     private int zPos = 0; //Initial z-axis location before updating with random value
-
+    private float crowSpeed = 5f;
     /// <summary>
     /// Instantiates a Crow gameobject at a position offscreen (x-axis) at a random point on the z-axis
     /// Start Coroutine to move the crow
@@ -66,25 +66,25 @@ public class CrowManager : MonoBehaviour
     private IEnumerator MoveCrow(GameObject crow)
     {
         //Show an alert when the crow spawns
+        yield return new WaitForSeconds(Random.Range(minSpawnDelay, maxSpawnDelay)); //Wait a random amount before 'respawning'
         StartCoroutine(ShowAlert()); 
 
         //Set values for time and start/end positions
-        float elapsedTime = 0f;
         Vector3 startPos = crow.transform.position;
         Vector3 endPos = new Vector3(endXPos, startPos.y, startPos.z);
 
         //Move the crow over time from a start to end point
-        while (elapsedTime < travelTime)
+        while (crow.transform.position.x > endPos.x)
         {
-            crow.transform.position = Vector3.Lerp(startPos, endPos, elapsedTime / travelTime);
-            elapsedTime += Time.deltaTime;
+            Vector3 position = crow.transform.position;
+            position.x -= Time.deltaTime * (crowSpeed + GameManager.instance.Speed); //Move crow towards end point
+            crow.transform.position = position;
             yield return null;
         }
 
         // Move to a new position offscreen and wait (after reaching the end)
         crow.transform.position = new Vector3(30f, 0f, 30f); //Offscreen location
-        yield return new WaitForSeconds(Random.Range(minSpawnDelay, maxSpawnDelay)); //Wait a random amount before 'respawning'
-
+   
         SpawnCrow(); //Respawn crow at new location and move again
     }
 

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -14,9 +14,7 @@
  */
 
 using System.Collections;
-using Unity.VisualScripting;
 using UnityEngine;
-using static UnityEngine.Rendering.DebugUI.Table;
 
 public class CrowManager : MonoBehaviour
 {

--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -33,7 +33,7 @@ public class CrowManager : MonoBehaviour
 
     [Header("Constant/Initial movement axis values")]
     private const int startXPos = 16; //Offscreen X location 'ahead' of the player
-    private const int endXPos = -5; //Offscreen X location 'behind' the player
+    private const int endXPos = -10; //Offscreen X location 'behind' the player
     private int zPos = 0; //Initial z-axis location before updating with random value
 
     /// <summary>

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -58,8 +58,7 @@ public class GameManager : MonoBehaviour
     public bool playerInCatchupZone = false;
 
     [Header("Crow settings")]
-    [SerializeField] private GameObject crowManagerParent;
-    private CrowManager crowManager;
+    [SerializeField] private CrowManager crowManager;
 
     /// <summary>
     /// The speed at which the tiles move
@@ -154,7 +153,6 @@ public class GameManager : MonoBehaviour
     /// </summary>
     private void SpawnCrow()
     {
-        crowManager = crowManagerParent.GetComponent<CrowManager>();
         crowManager.GetAlertFromPlayer(); //Get alert reference for newly spawned player
         crowManager.SpawnCrow(); //Spawn crow/start movement
     }
@@ -164,7 +162,6 @@ public class GameManager : MonoBehaviour
     /// </summary>
     private void CrowGameOver()
     {
-        crowManager = crowManagerParent.GetComponent<CrowManager>();
         crowManager.GameOver(); //Stop any crow movement and shift offscreen
     }
 

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -155,10 +155,13 @@ public class GameManager : MonoBehaviour
     private void SpawnCrow()
     {
         crowManager = crowManagerParent.GetComponent<CrowManager>();
-        crowManager.GetAlertFromPlayer();
+        crowManager.GetAlertFromPlayer(); //Needed for when new player spawned after reset to remove console error
         crowManager.Start();
     }
 
+    /// <summary>
+    /// Stops any more crow movement and moves to offscreen location for game reset
+    /// </summary>
     private void ResetCrow()
     {
         crowManager = crowManagerParent.GetComponent<CrowManager>();

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -137,6 +137,7 @@ public class GameManager : MonoBehaviour
     {
         gameStarted = false;
         GameoverPanel.SetActive(true);
+        ResetCrow();
         Destroy(playerController.gameObject);
     }
 
@@ -154,7 +155,14 @@ public class GameManager : MonoBehaviour
     private void SpawnCrow()
     {
         crowManager = crowManagerParent.GetComponent<CrowManager>();
+        crowManager.GetAlertFromPlayer();
         crowManager.Start();
+    }
+
+    private void ResetCrow()
+    {
+        crowManager = crowManagerParent.GetComponent<CrowManager>();
+        crowManager.GameOver();
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -47,16 +47,19 @@ public class GameManager : MonoBehaviour
     [SerializeField] private float maxBaseSpeed = 4; // The maximum speed of the game independent of the catchup mechanic
     [SerializeField] private float accelerationCurve = 1.5f; // The speed at which the "camera" catches up to player (lower is faster)
     [SerializeField] private float decelerationCurve = 0.5f; // The speed at which the "camera" slows back down (lower is faster)
-    
+
     private float baseSpeed; // The speed of the game independent of the catchup mechanic
     private float initSpeed = 1; // The initial speed  
     private float decelerationTolerance = 0.1f; // The tolerance for the speed to be considered back to normal
     private float currentVelocity = 0f;
-  
+
 
     private bool isCatchingUp;
     public bool playerInCatchupZone = false;
 
+    [Header("Crow settings")]
+    [SerializeField] private GameObject crowManagerParent;
+    private CrowManager crowManager;
 
     /// <summary>
     /// The speed at which the tiles move
@@ -105,6 +108,7 @@ public class GameManager : MonoBehaviour
         GameoverPanel.SetActive(false);
         tileManager.InitTileGrid();
         SpawnPlayer();
+        SpawnCrow();
         gameStarted = true;
     }
 
@@ -142,6 +146,15 @@ public class GameManager : MonoBehaviour
     private void SpawnPlayer()
     {
         playerController = tileManager.InstantiateOnTile(playerPrefab, playerStartCoords).GetComponent<PlayerController>();
+    }
+
+    /// <summary>
+    /// Gets a reference to the manager script attached to scene object and calls Start() to spawn a new crow
+    /// </summary>
+    private void SpawnCrow()
+    {
+        crowManager = crowManagerParent.GetComponent<CrowManager>();
+        crowManager.Start();
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -137,7 +137,7 @@ public class GameManager : MonoBehaviour
     {
         gameStarted = false;
         GameoverPanel.SetActive(true);
-        ResetCrow();
+        CrowGameOver();
         Destroy(playerController.gameObject);
     }
 
@@ -150,22 +150,22 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Gets a reference to the manager script attached to scene object and calls Start() to spawn a new crow
+    /// Gets a reference to new player alert object and spawns a new crow
     /// </summary>
     private void SpawnCrow()
     {
         crowManager = crowManagerParent.GetComponent<CrowManager>();
-        crowManager.GetAlertFromPlayer(); //Needed for when new player spawned after reset to remove console error
-        crowManager.Start();
+        crowManager.GetAlertFromPlayer(); //Get alert reference for newly spawned player
+        crowManager.SpawnCrow(); //Spawn crow/start movement
     }
 
     /// <summary>
     /// Stops any more crow movement and moves to offscreen location for game reset
     /// </summary>
-    private void ResetCrow()
+    private void CrowGameOver()
     {
         crowManager = crowManagerParent.GetComponent<CrowManager>();
-        crowManager.GameOver();
+        crowManager.GameOver(); //Stop any crow movement and shift offscreen
     }
 
     /// <summary>


### PR DESCRIPTION
I've worked a bit on getting the new player and crow functioning in the `BoundaryTestScene` as I figure that is likely to be the basis for our main scene.

Current Features:
 - New player prefab used (with PlayerController script added)
 - Player tag added to entire Player prefab for catchup/gameover triggers
 - Added to GameManager to Start and Stop crow spawning
 - Added CrowManager to scene
 -  Removed CrowManager start being used to control initial crow spawning and moved to game manager entirely (was causing issue where the crow was technically being moved twice so would despawn in half the time)

Current issues:
 - When the player enters the 'Catchup' trigger area, the crows speed does not in any way increase to match the faster moving ground. This results in a slightly jittery movement of the crow when it appears to only move a little/almost lock in place. I am unsure how to modify my speed calculations to accurately reflect this potential change in game speed. Might need some help getting this fixed if it is too jarring

