### PR TITLE
Crow spawning adjusted to game boundary

### DIFF
--- a/Assets/Scripts/Crow/CrowManager.cs
+++ b/Assets/Scripts/Crow/CrowManager.cs
@@ -35,6 +35,8 @@ public class CrowManager : MonoBehaviour
     private const int startXPos = 16; //Offscreen X location 'ahead' of the player
     private const int endXPos = -10; //Offscreen X location 'behind' the player
     private int zPos = 0; //Initial z-axis location before updating with random value
+    private const int minZPos = 1; //Boundary Z-pos at right side of screen
+    private const int maxZPos = 10;//Boundary Z-pos at left side of screen
     private float crowSpeed = 5f;
 
 
@@ -94,7 +96,7 @@ public class CrowManager : MonoBehaviour
     /// Sets a random z-axis starting position within player move space
     /// </summary>
     /// <returns>z position for new crow spawn location</returns>
-    private int GetRandomZPos() => Random.Range(2, 9);
+    private int GetRandomZPos() => Random.Range(minZPos, maxZPos);
 
     /// <summary>
     /// Stops movement of crow and moves offscreen for new game spawning 


### PR DESCRIPTION
### Description
Very simple PR to fix an issue that was found during the Games Showcase. This modifies the code calculation for Crow Z position to more closely match the maximum playable range of the player. New min/max positions will at least have the crow over the boundary fence, meaning that the crow shadow now covers all playable tile space.

Branch:
`Devon/Crow-Boundary-Fix`

Resolves Issue:
 - #29

Crow at right boundary:
![crow1](https://github.com/LiamMcKenzie/ScaredKrow/assets/90590089/0e700c3b-1ec4-4024-a449-52f6a3b140b7)

Crow at left boundary:
![crow 2](https://github.com/LiamMcKenzie/ScaredKrow/assets/90590089/3559c55e-270f-4713-a17f-929515f7fe40)


