### PR TITLE
Catchup Area Reset - Bugfix

### DIFF
--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -123,6 +123,7 @@ public class GameManager : MonoBehaviour
     {
         Speed = initSpeed;
         isCatchingUp = false;
+        playerInCatchupZone = false;
         score = 0;
         backMovements = 0;
         Init();


### PR DESCRIPTION
### Description:
When the player dies in the catchup trigger area, the bool for checking if the player is in catchup zone doesn't reset to false. This PR is a simple addition of setting the bool back to false in the GameManager on Reset()

Easier to show with video and I've included the inspector values at the side so you can see it happening.

Branch:
`Devon/Fix-Catchup-Reset-Bug`

Fixes Issue:
 - #31 

Before fix:

https://github.com/LiamMcKenzie/ScaredKrow/assets/90590089/048e6fac-1a19-44f0-84df-e7df7adf31aa



After fix:
_Bool is still set to true when the game ends but sets immediately to false when 'Play Again' is clicked and Reset() is called._


https://github.com/LiamMcKenzie/ScaredKrow/assets/90590089/bf2edb8d-9685-4b0d-ace4-92adf33db22d




